### PR TITLE
Auto-register drivers

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ NDS provides the following features:
 
 ## Developer Dependencies
 
-At least cmake 2.8.2 required. Included in RHEL 6.6, Debian Wheezy, Ubuntu Trusty.
+cmake 2.8.2+ required to run unit tests. Included in RHEL 6.6, Debian Wheezy, Ubuntu Trusty.
+
+GCC 4.9+ is recommended because of [GCC 57869](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=57869).
 
 ## Package Installation
 

--- a/doc/api/200_namingRules.dox
+++ b/doc/api/200_namingRules.dox
@@ -48,7 +48,7 @@ void getTemperature(timespec* pTimestamp, double* pValue)
 //  as a dynamic module and we have to provide the functions to allocate it,
 //  deallocate it and retrieve its name
 ////////////////////////////////////////////////////////////////////////////////
-NDS_DEFINE_DRIVER("Thermometer", Thermometer);
+NDS_DEFINE_DRIVER(Thermometer, Thermometer);
 @endcode
 
 For instance, if we create the device on an EPICS IOC we will see the following:

--- a/doc/examples/oscilloscope/oscilloscope.cpp
+++ b/doc/examples/oscilloscope/oscilloscope.cpp
@@ -405,7 +405,7 @@ void Oscilloscope::acquireSquareWave()
         size_t maxAmplitude = m_squareWaveAmplitude.getValue();
         for(size_t scanVector(0); scanVector != outputData.size(); ++scanVector)
         {
-            outputData[scanVector] = (angle & 0xff < 128) ? maxAmplitude : - maxAmplitude;
+            outputData[scanVector] = ((angle & 0xff) < 128) ? maxAmplitude : - maxAmplitude;
         }
 
         // Push the vector to the control system
@@ -418,4 +418,4 @@ void Oscilloscope::acquireSquareWave()
     }
 }
 
-NDS_DEFINE_DRIVER("Oscilloscope", Oscilloscope);
+NDS_DEFINE_DRIVER(Oscilloscope, Oscilloscope)

--- a/doc/examples/oscilloscopeMultiChannel/oscilloscopeMultiChannel.cpp
+++ b/doc/examples/oscilloscopeMultiChannel/oscilloscopeMultiChannel.cpp
@@ -289,4 +289,4 @@ void Channel::acquisitionLoop()
 // The following MACRO defines the function to be exported in order
 //  to allow the dynamic loading of the shared module
 ///////////////////////////////////////////////////////////////////
-NDS_DEFINE_DRIVER("OscilloscopeMultiChannel", Oscilloscope);
+NDS_DEFINE_DRIVER(OscilloscopeMultiChannel, Oscilloscope)

--- a/doc/examples/thermometer/thermometer.cpp
+++ b/doc/examples/thermometer/thermometer.cpp
@@ -31,5 +31,5 @@ public:
 //  as a dynamic module and we have to provide the functions to allocate it,
 //  deallocate it and retrieve its name
 ////////////////////////////////////////////////////////////////////////////////
-NDS_DEFINE_DRIVER("Thermometer", Thermometer);
+NDS_DEFINE_DRIVER(Thermometer, Thermometer)
 

--- a/include/nds3/definitions.h
+++ b/include/nds3/definitions.h
@@ -294,7 +294,7 @@ typedef std::list<std::string> enumerationStrings_t;
  * @brief Defines the global functions that are called by NDS when the device class needs
  *        to be allocated.
  *
- * @param driverName   a string that specifies the driver name
+ * @param driverName   a token that specifies the driver name (input has to be valid c symbol name)
  * @param className    the name of the class that implements the driver
  */
 #define NDS_DEFINE_DRIVER(driverName, className)\
@@ -310,8 +310,9 @@ void deallocateDevice(void* device) \
 } \
 const char* getDeviceName() \
 { \
-    return driverName; \
+    return #driverName; \
 } \
+nds::RegisterDevice<className> registerDevice##driverName(#driverName); \
 } // extern "C"
 
 // Generic helper definitions for shared library support

--- a/include/nds3/nds.h
+++ b/include/nds3/nds.h
@@ -34,6 +34,7 @@
 #include "nds3/factory.h"
 #include "nds3/stateMachine.h"
 #include "nds3/thread.h"
+#include "nds3/registerDevice.h"
 
 
 #endif // NDS3_H

--- a/include/nds3/registerDevice.h
+++ b/include/nds3/registerDevice.h
@@ -1,0 +1,40 @@
+#ifndef NDSREGISTER_DEVICE_H
+#define NDSREGISTER_DEVICE_H
+
+namespace nds
+{
+
+/**
+ * @brief This is a class intended to be used as a static class for automatic registering of device supports
+ */
+template <class T>
+class NDS3_API RegisterDevice
+{
+private:
+    const std::string m_driverName;
+
+public:
+    RegisterDevice(const char *driverName) : m_driverName(std::string(driverName)) {
+        nds::Factory::registerDriver(m_driverName, RegisterDevice<T>::allocateDevice, RegisterDevice<T>::deallocateDevice);
+    }
+
+    static void *allocateDevice(nds::Factory& factory, const std::string& device, const nds::namedParameters_t& parameters){
+        return new T(factory, device, parameters);
+    }
+
+    static void deallocateDevice(void *device) {
+        delete (T *)device;
+    }
+
+    const char *getDriverName() {
+        return m_driverName;
+    }
+
+protected:
+    RegisterDevice();
+
+};
+} /* namespace nds */
+
+
+#endif /* NDSREGISTER_DEVICE_H */

--- a/src/ndsFactoryImpl.cpp
+++ b/src/ndsFactoryImpl.cpp
@@ -136,9 +136,12 @@ void NdsFactoryImpl::registerDriver(const std::string &driverName, allocateDrive
 
     if(m_driversAllocDealloc.find(driverName) != m_driversAllocDealloc.end())
     {
-        std::ostringstream error;
-        error << "The driver " << driverName << " has already been registered";
-        throw DriverAlreadyRegistered(error.str());
+        // TODO(nc): Implement NDS debug. Below is not an error, but would it be
+        //           nice to print if debugging NDS.
+        //std::ostringstream error;
+        //error << "The driver " << driverName << " has already been registered";
+        //std::cerr << error.str();
+        //throw DriverAlreadyRegistered(error.str());
     }
     m_driversAllocDealloc[driverName] = std::pair<allocateDriver_t, deallocateDriver_t>(allocateFunction, deallocateFunction);
 }


### PR DESCRIPTION
If drivers are loaded through some other mechanism than `ndsLoadDriver`
they are automatically registered with NDS, for example if GNU Linker
loads the library.

All drivers have to be recompiled to support auto-registering. They
can still be loaded with `ndsLoadDriver` however.