### PR TITLE
Add changelog, contributing and maintenance docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+## [Unreleased]
+
+## [3.1.0] - 2017-07-07
+
+### Added
+- Support for autoregistering device drivers
+- Support for RPC like behavior with PVAction types. Thanks @wbshi!
+
+### Changed
+- Moved `impl` headers to subdirectory. Thanks @ralphlange!
+
+### Removed
+- Make and QMake build systems
+
+## [3.0.0] - 2017-01-07
+
+### Added
+- Initial NDS3 implementation
+
+[Unreleased]: https://github.com/cosylab/nds3/compare/v3.1.0...HEAD
+[3.1.0]: https://github.com/cosylab/nds3/compare/v3.0.0...v3.1.0
+[3.0.0]: https://github.com/cosylab/nds3/compare/c3048bc...v3.0.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,31 @@
+# Contribute to NDS
+Thank you for your interest in contributing to NDS!
+
+It is possible to contribute in multiple ways. You can for example file a bug
+report, improve the documentation or improve the implementation. We are very
+interested to hear from you if you considered to or considered not to use NDS
+for your driver development.
+
+If you have an idea for improvement of NDS we welcome you to open an issue in
+[the issue tracker](https://github.com/Cosylab/nds3/issues). Opening an issue
+before starting any development will increase the success rate of that
+contribution to eventually get merged. When the overall design of the change
+has been decided fork the repository and implement the changes in your fork.
+Finally when you want feedback on the code, open a pull request.
+
+## General guidelines
+- Prefix your PR subject with "[WIP]" if it isn't ready to be merged.
+- Rebase/Squash your commits to reasonably sized commits.
+   * BUT: Don't rebase your branch until code reviewing is done. This makes it
+     easier to follow the discussions in the PR.
+   * Finally, every commit should be self-contained and should build.
+- Write descriptive commit messages.
+   * First line should be in imperative form, starting with a capital letter
+     and not end with punctuation. Same rules as for a header. It should
+     complete the sentance "If applied, this commit will ..."
+   * Second line should always be empty.
+   * The rest of the message should explain the introduced changes in more
+     detail.
+- Follow the same coding style as the rest of the code.
+- We currently target C++11, so please avoid GNU/MSVC specifics or features
+  from later C++ standards.

--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -1,0 +1,12 @@
+# NDS Maintannce policy
+
+NDS follows [semantic versioning](http://www.semver.org) in a pragmatic way.
+
+* Major version: Whenever there is something significant or any backwards
+  incompatible changes are introduced to the public API.
+* Minor version: When new, backwards compatible functionality is introduced to
+  the public API or a minor feature is introduced, or when a set of smaller
+  features is rolled out.
+* Patch number: When backwards compatible bug fixes are introduced that fix
+  incorrect behavior.
+* Label: An rcN label is used if one or more release candidates are released.


### PR DESCRIPTION
This commit adds a changelog, a contributing and a maintenance file
to guide developers of NDS.