### PR TITLE
[WIP] added a missing method 

### DIFF
--- a/doc/examples/thermometer/thermometer.cpp
+++ b/doc/examples/thermometer/thermometer.cpp
@@ -1,16 +1,24 @@
 #include <nds3/nds.h>
+#include <iostream>
 
 // This class declares our device in the contructor and supplies the functionalities to support it
 //////////////////////////////////////////////////////////////////////////////////////////////////
 class Thermometer
 {
+private:
+	nds::PVDelegateIn<double> m_thermometerPiniPV;
+
 public:
 
     // Constructor. Here we setup the device structure
     //////////////////////////////////////////////////
     Thermometer(nds::Factory &factory,
                 const std::string &deviceName,
-                const nds::namedParameters_t &parameters)
+                const nds::namedParameters_t &parameters) :
+	m_thermometerPiniPV(nds::PVDelegateIn<double>("TemperaturePINI", std::bind(&Thermometer::getTempRandom, 
+                                                                             this, 
+                                                                             std::placeholders::_1, 
+                                                                             std::placeholders::_2)))
     {
         nds::Port rootNode(deviceName);
         rootNode.addChild(nds::PVDelegateIn<double>("Temperature", std::bind(&Thermometer::getTemperature, 
@@ -18,12 +26,22 @@ public:
                                                                              std::placeholders::_1, 
                                                                              std::placeholders::_2)));
 
+	m_thermometerPiniPV.processAtInit(1);
+	rootNode.addChild(m_thermometerPiniPV);
+
         rootNode.initialize(this, factory);
     }
 
     void getTemperature(timespec* pTimestamp, double* pValue)
     {
         *pValue = 10; // It is always cold in here
+	std::cout << "Temperature #1: " << *pValue << std::endl;
+    }
+
+    void getTempRandom(timespec* pTimestamp, double* pValue)
+    {
+        *pValue = 35; // It is always hot right there
+	std::cout << "Temperature #2 (pini): " << *pValue << std::endl;
     }
 };
 

--- a/src/pvBase.cpp
+++ b/src/pvBase.cpp
@@ -82,4 +82,13 @@ void PVBase::setMaxElements(const size_t maxElements)
     std::static_pointer_cast<PVBaseImpl>(m_pImplementation)->setMaxElements(maxElements);
 }
 
+/*
+ * SSpecifies if the PV has to be processed during the device initialization
+ *
+ ****************************************************************************/
+void PVBase::processAtInit(const bool bProcessAtInit)
+{
+    std::static_pointer_cast<PVBaseImpl>(m_pImplementation)->processAtInit(bProcessAtInit);
+}
+
 }


### PR DESCRIPTION
If applied, this commit will allow to use nds::PVBase::proccesAtInit(bool) method in the NDS3 applications.

The definition of processAtInit method was missing. Added to the code.